### PR TITLE
Expose (Q)SPI pins to access flash memory

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -53,7 +53,7 @@ impl Board {
                        gpioc: hal::gpio::gpioc::Parts,
                        gpiod: hal::gpio::gpiod::Parts,
                        gpioe: hal::gpio::gpioe::Parts,
-                       _gpiof: hal::gpio::gpiof::Parts,
+                       gpiof: hal::gpio::gpiof::Parts,
                        gpiog: hal::gpio::gpiog::Parts) -> Pins {
         Pins {
             SEED_PIN_0: gpiob.pb12,
@@ -96,7 +96,14 @@ impl Board {
                 SD_A:   gpioe.pe6,  // SAI1 SD_A
                 SD_B:   gpioe.pe3,  // SAI1 SD_B
             },
-            FMC: (),
+            FMC: FMCPins {
+                IO0: gpiof.pf8,
+                IO1: gpiof.pf9,
+                IO2: gpiof.pf7,
+                IO3: gpiof.pf6,
+                SCK: gpiof.pf10,
+                CS:  gpiog.pg6,
+            },
             SDRAM: (),
             USB2: USB2Pins {
                 DN: gpioa.pa11, // USB2 D-

--- a/src/pins.rs
+++ b/src/pins.rs
@@ -52,6 +52,17 @@ pub struct USB2Pins {
     pub DP: hal::gpio::gpioa::PA12<hal::gpio::Analog>,  // USB2 D+
 }
 
+#[allow(non_snake_case)]
+pub struct FMCPins {
+    // https://github.com/electro-smith/libDaisy/blob/3dda55e9ed55a2f8b6bc4fa6aa2c7ae134c317ab/src/per/qspi.c#L695
+    pub IO0: hal::gpio::gpiof::PF8<hal::gpio::Analog>,  // (SI)
+    pub IO1: hal::gpio::gpiof::PF9<hal::gpio::Analog>,  // (SO)
+    pub IO2: hal::gpio::gpiof::PF7<hal::gpio::Analog>,
+    pub IO3: hal::gpio::gpiof::PF6<hal::gpio::Analog>,
+    pub SCK: hal::gpio::gpiof::PF10<hal::gpio::Analog>,
+    pub CS: hal::gpio::gpiog::PG6<hal::gpio::Analog>,
+}
+
 
 // - Pins ---------------------------------------------------------------------
 
@@ -93,7 +104,7 @@ pub struct Pins {
     // board peripherals
     pub LED_USER: LedUserPin,
     pub AK4556: AK4556Pins,
-    pub FMC: (),   // TODO
+    pub FMC: FMCPins,
     pub SDRAM: (), // TODO
     pub USB2: USB2Pins,
 }


### PR DESCRIPTION
This patch exposes pins connected to the flash memory on board (IS25LP064A) through the Board abstraction.

Although this does not introduce a high level library to access the memory, it does allow for experimentation with standard SPI and QuadSPI interfaces available in stm32h7xx-hal.

Meanwhile, I'm preparing a [simple driver for the memory](https://github.com/phoracek/daisy_bsp/pull/1),
