### PR TITLE
Fix a docstring bug

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,6 @@
 //! Board support crate for Daisy hardware
 //!
 //! # Usage - see examples/
-//! ```
 
 
 // - modules ------------------------------------------------------------------


### PR DESCRIPTION
Due to this unclosed code block, `cargo doc` will fail with:

```
error: Rust code block is empty
 --> src/lib.rs:9:5
  |
9 | //! ```
  |     ^^^
```

This patch fixes it.

Signed-off-by: Petr Horacek <hrck@protonmail.com>