### PR TITLE
audio::Interface::start → audio::Interface::spawn in test_signal example

### DIFF
--- a/examples/audio_testsignal.rs
+++ b/examples/audio_testsignal.rs
@@ -85,7 +85,7 @@ fn main() -> ! {
             }
         }
 
-        audio_interface.start(callback)
+        audio_interface.spawn(callback)
     };
 
     // handle callback with closure (needs alloc)


### PR DESCRIPTION
Minor fix for the change from `audio::Interface::start` to `audio::Interface::spawn`, in the non-alloc-only version of examples/audio_testsignal.rs