### PR TITLE
Bump HAL to 0.11.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ targets = ["thumbv7em-none-eabihf"]
 [dependencies]
 cortex-m = "^0.7.1"
 cortex-m-rt = { version = "^0.6.13", features = ["device"] }
-stm32h7xx-hal = { version = "0.9.0", features = [ "stm32h750v", "rt", "revision_v", "usb_hs" ] }
+stm32h7xx-hal = { version = "0.11.0", features = [ "stm32h750v", "rt", "revision_v", "usb_hs" ] }
 cty = "0.2.1"
 cortex-m-semihosting = "0.3.5"
 

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -5,7 +5,7 @@ use stm32h7xx_hal as hal;
 use hal::gpio;
 use hal::time;
 use hal::dma;
-use hal::sai::{ self, SaiI2sExt, SaiChannel };
+use hal::sai::{ self, SaiI2sExt, SaiChannel, I2sUsers };
 
 use hal::hal as embedded_hal;
 use embedded_hal::digital::v2::OutputPin;
@@ -148,8 +148,7 @@ impl<'a> Interface<'a> {
             sai::I2SDataSize::BITS_24,
             sai1_rec,
             clocks,
-            sai1_tx_config,
-            Some(sai1_rx_config),
+            I2sUsers::new(sai1_tx_config).add_slave(sai1_rx_config),
         );
 
         Ok(Self {


### PR DESCRIPTION
The I2S constructor had to be change as its signature changed.

New features brought by this change are listed in https://github.com/stm32-rs/stm32h7xx-hal/blob/master/CHANGELOG.md.

A follow-up patch will leverage these to introduce a driver for the
flash memory.

Signed-off-by: Petr Horacek <hrck@protonmail.com>