### PR TITLE
rework to no longer use the path alloc::prelude, as it's now removed

### DIFF
--- a/src/audio.rs
+++ b/src/audio.rs
@@ -1,5 +1,5 @@
 #[cfg(any(feature = "alloc"))] extern crate alloc;
-#[cfg(any(feature = "alloc"))] use alloc::prelude::v1::Box;
+#[cfg(any(feature = "alloc"))] use alloc::boxed::Box;
 
 use stm32h7xx_hal as hal;
 use hal::gpio;
@@ -155,7 +155,7 @@ impl<'a> Interface<'a> {
             fs: FS,
 
             #[cfg(not(feature = "alloc"))] function_ptr: None,
-            #[cfg(any(feature = "alloc"))] closure: None,
+            #[cfg(any(feature = "alloc"))] closure: Option::None,
 
             ak4556_reset: Some(pins.0),
             hal_dma1_stream0: Some(dma1_str0),

--- a/src/midi.rs
+++ b/src/midi.rs
@@ -1,5 +1,5 @@
 #[cfg(any(feature = "alloc"))] extern crate alloc;
-#[cfg(any(feature = "alloc"))] use alloc::prelude::v1::Box;
+#[cfg(any(feature = "alloc"))] use alloc::boxed::Box;
 
 pub use stm32h7xx_hal as hal;
 use hal::prelude::*;
@@ -50,7 +50,7 @@ impl<'a> Interface<'a> {
                     tx,
 
                     #[cfg(not(feature = "alloc"))] function_ptr: None,
-                    #[cfg(any(feature = "alloc"))] closure: None,
+                    #[cfg(any(feature = "alloc"))] closure: Option::None,
 
                     _marker: core::marker::PhantomData
                 })


### PR DESCRIPTION
Updated to a recent nightly and couldn't build the examples, but this patch got it building again & I confirmed that the examples still work. 

See: https://github.com/rust-lang/rust/issues/90322