### PR TITLE
Fix build errors in examples

### DIFF
--- a/examples/adc_bsp.rs
+++ b/examples/adc_bsp.rs
@@ -37,6 +37,8 @@ fn main() -> ! {
         dp.GPIOE.split(ccdr.peripheral.GPIOE),
         dp.GPIOF.split(ccdr.peripheral.GPIOF),
         dp.GPIOG.split(ccdr.peripheral.GPIOG),
+        dp.GPIOH.split(ccdr.peripheral.GPIOH),
+        dp.GPIOI.split(ccdr.peripheral.GPIOI),
     );
 
     // - adc ------------------------------------------------------------------

--- a/examples/audio_testsignal.rs
+++ b/examples/audio_testsignal.rs
@@ -46,6 +46,8 @@ fn main() -> ! {
         dp.GPIOE.split(ccdr.peripheral.GPIOE),
         dp.GPIOF.split(ccdr.peripheral.GPIOF),
         dp.GPIOG.split(ccdr.peripheral.GPIOG),
+        dp.GPIOH.split(ccdr.peripheral.GPIOH),
+        dp.GPIOI.split(ccdr.peripheral.GPIOI),
     );
 
     let mut led_user = daisy_bsp::led::UserLed::new(pins.LED_USER);

--- a/examples/blinky.rs
+++ b/examples/blinky.rs
@@ -25,6 +25,8 @@ fn main() -> ! {
         dp.GPIOE.split(ccdr.peripheral.GPIOE),
         dp.GPIOF.split(ccdr.peripheral.GPIOF),
         dp.GPIOG.split(ccdr.peripheral.GPIOG),
+        dp.GPIOH.split(ccdr.peripheral.GPIOH),
+        dp.GPIOI.split(ccdr.peripheral.GPIOI),
     );
 
     let mut led_user = daisy::led::UserLed::new(pins.LED_USER);

--- a/examples/flash.rs
+++ b/examples/flash.rs
@@ -25,6 +25,8 @@ fn main() -> ! {
         dp.GPIOE.split(ccdr.peripheral.GPIOE),
         dp.GPIOF.split(ccdr.peripheral.GPIOF),
         dp.GPIOG.split(ccdr.peripheral.GPIOG),
+        dp.GPIOH.split(ccdr.peripheral.GPIOH),
+        dp.GPIOI.split(ccdr.peripheral.GPIOI),
     );
 
     let mut led_user = daisy::led::UserLed::new(pins.LED_USER);

--- a/examples/itm.rs
+++ b/examples/itm.rs
@@ -28,6 +28,8 @@ fn main() -> ! {
         dp.GPIOE.split(ccdr.peripheral.GPIOE),
         dp.GPIOF.split(ccdr.peripheral.GPIOF),
         dp.GPIOG.split(ccdr.peripheral.GPIOG),
+        dp.GPIOH.split(ccdr.peripheral.GPIOH),
+        dp.GPIOI.split(ccdr.peripheral.GPIOI),
     );
 
     let mut user_led = daisy_bsp::led::UserLed::new(pins.LED_USER);


### PR DESCRIPTION
This was broken due to a659d7b requiring GPIOH and GPIOI in the `split_gpios` function.