### PR TITLE
Increase frequency accuracy of audio PLL clock

### DIFF
--- a/src/clocks.rs
+++ b/src/clocks.rs
@@ -50,6 +50,7 @@ pub fn configure(pwr: pwr::Pwr, rcc: rcc::Rcc, syscfg: &pac::SYSCFG) -> rcc::Ccd
     let ccdr = rcc
         .use_seed_crystal() // high speed external crystal @ 16 MHz
         .pll1_strategy(rcc::PllConfigStrategy::Iterative) // pll1 drives system clock
+        .pll3_strategy(rcc::PllConfigStrategy::Fractional) // ensure we get as close as possible to 12.288 MHz (audio clock)
         .sys_ck(480.MHz()) // system clock @ 480 MHz
         .pll1_q_ck(48.MHz()) // spi display @ 48 MHz
         .pll3_p_ck(PLL3_P) // audio clock  @ 12.288 MHz
@@ -60,6 +61,7 @@ pub fn configure(pwr: pwr::Pwr, rcc: rcc::Rcc, syscfg: &pac::SYSCFG) -> rcc::Ccd
     let ccdr = rcc
         .use_seed_crystal() // high speed external crystal @ 16 MHz
         .pll1_strategy(rcc::PllConfigStrategy::Iterative) // pll1 drives system clock
+        .pll3_strategy(rcc::PllConfigStrategy::Fractional) // ensure we get as close as possible to 12.288 MHz (audio clock)
         .sys_ck(480.MHz()) // system clock @ 480 MHz
         .pll1_q_ck(48.MHz()) // spi display @ 48 MHz
         .pll1_r_ck(480.MHz()) // for TRACECK


### PR DESCRIPTION
Unfortunately (and I don't know why they made that choice, it's baffling) the Daisy Seed boards feature a 16 MHz crystal instead of some standard audio crystal with 12.288 MHz.

That means we have to PLL our way as close as possible to 12.288 MHz. The default configuration of the STM32H7 HAL is to use non-fractional mode. Supposedly, non-fractional mode has less jitter. Unfortunately, non-fractional mode doesn't get us close enough to 48 kHz * 256 to be accurate. I measured the LRCLK/FS (whose frequency is equal to the sample rate) using a scope and it ended up at 47.75 kHz, which is a 0.5% difference.

This probably doesn't matter when exclusively using the on-board codec, however, when interfacing with other stuff over SAI2, it starts to matter. In my practical example, I'm using a Raspberry Pi Pico 2 which gets (and sends) audio data from the Daisy Seed via USB audio over SAI2. Here, I noticed glitching because of overruns/underruns and resulting phase shifts with the default configuration.

Switching the PLL3 to use fractional clock generation changes the LRCLK/FS frequency to 48.00 kHz according to my scope. This removed *almost* all of the glitches, even though they are not completely gone (I suspect there's still a difference in the third or fourth digit behind the comma. This will need asynchronous sample rate conversion in user code to mitigate.)